### PR TITLE
【 修正 】SSL 証明書の CN や O が undefined だったときの storage の値

### DIFF
--- a/js/pkg/content.js
+++ b/js/pkg/content.js
@@ -1,5 +1,5 @@
 import * as certInfo from './certificate-Info.js';
-import * as storage from './storage.js';
+// import * as storage from './storage.js';
 import * as url from './url.js';
 
 const storageCache = {};
@@ -14,17 +14,16 @@ export async function updateTab(tab) {
     )
     chrome.storage.session.set(
         {
-            'commonName': commonName,
-            'organization': organization
+            'commonName': typeof commonName !== 'undefined' ? commonName : 'Unknown',
+            'organization': typeof organization !== 'undefined' ? organization : 'Unknown'
             // 後に脅威情報リンクも追記する
         }
     );
-    storage.assignStorageCache(storageCache);
 
     console.log('commonName: ' + commonName);
     console.log('Organization: ' + organization);
 
     // ↓ のような感じで、storageCache に保存した情報を取得する
-    // storage.assignStorageCache(storageCache);
+    // await storage.assignStorageCache(storageCache);
     // console.log(storageCache);
 }


### PR DESCRIPTION
取得した SSL 証明書の CN や O が undefined だったとき、storage に代入する値を変更しました。
- 理由
  - storage.session.set 渡す値が undefined のとき、storage に登録されないような挙動だったため
    - 上書きされないと、他のタブでの情報を正しく表示できないことがある