### PR TITLE
【 機能 】タブ変更時の自動情報更新

### DIFF
--- a/js/bg.js
+++ b/js/bg.js
@@ -1,5 +1,16 @@
 import * as content from "./pkg/content.js";
 
+chrome.tabs.onActivated.addListener(async(activeInfo) => {
+    chrome.tabs.query({}, async(tabs) => {
+        for (let i = 0; i < tabs.length; i++) {
+            if (tabs[i].id === activeInfo.tabId) {
+                await content.updateTab(tabs[i]);
+                break;
+            }
+        }
+    })
+});
+
 chrome.tabs.onUpdated.addListener(async(tabId, changeInfo, tab) => {
     if (!tab.highlighted) {
         return;


### PR DESCRIPTION
github のタブにいて、qiita のタブに移ったとき
- いままで: リロードしなければ、情報が更新されなかった
- この機能: リロードせずに情報が更新される