### PR TITLE
【バグ修正】表示されたボタンが消えないバグに対する修正

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -20,6 +20,8 @@ function addElements(certInfo) {
 function addButtons(certInfo) {
     if (!($('body').length)) return false; // htmlのbodyがなければ追加をやめる
 
+    if (($('#printOrg').length)) return true; // すでに存在する場合は追加しない
+
     // organizationが不明なら簡易的な警告を出す
     let printText = certInfo.organization;
     if (certInfo.organization == "Unknown") {


### PR DESCRIPTION
- bg.jsでupdateTab()が同時に複数発火するURLが存在し，同じIDが付与されたボタンが複数追加されるため，消えないボタンが生まれたのが原因であると判明
  - フロントエンドのcontent.js内で同じIDのボタンが既に存在する場合は新たに追加しないように修正