### PR TITLE
【 エラー処理 】SSL 情報が不完全なときの処理

### DIFF
--- a/js/pkg/content.js
+++ b/js/pkg/content.js
@@ -12,7 +12,16 @@ export async function updateTab(tab) {
         url.getCurrentTabUrl(tab),
         async (res) => {
             var j = await res.json();
-            return [j.message.subject.CN, j.message.subject.O];
+            try {
+                return [j.message.subject.CN, j.message.subject.O];
+            } catch (err) {
+                if (err instanceof TypeError) {
+                    console.log("hi");
+                    return [undefined, undefined];
+                } else {
+                    console.log(err);
+                }
+            }
         }
     )
 
@@ -47,6 +56,7 @@ export async function updateTab(tab) {
             })
             .catch((error) => {
                 // エラー処理
+                console.log(error);
             });
     }
 }

--- a/js/pkg/content.js
+++ b/js/pkg/content.js
@@ -56,7 +56,6 @@ export async function updateTab(tab) {
             })
             .catch((error) => {
                 // エラー処理
-                console.log(error);
             });
     }
 }


### PR DESCRIPTION
SSL 証明書の情報が不完全なときがある（Gmail とか正常に取得できない）
このとき、SSL 証明書の情報を取得しようとすると、エラーが発生して、その後正しい処理がおこなわれない問題があった
そこで、エラー処理を追加して、その後の処理への影響を小さくするようにした