### PR TITLE
【 修正 】bootstrap の js による意図しない影響について

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,6 @@
         "<all_urls>"
       ],
       "js": [
-        "js/bootstrap.bundle.min.js",
         "js/jquery-3.6.1.min.js",
         "js/content.js"
       ],


### PR DESCRIPTION
- 一部サイトで、メニューを開いたのち、畳めない状態になる不具合があった
- 原因は、`manifest.json` の `content-scripts` の `js` から `bootstrap.bundle.min.js` を読み込んでいるところにあった
  - この js が読み込まれることにより、ページ側に影響が出ている
- `manifest.json` で  `bootstrap.bundle.min.js` を読み込まないようにすることで対応