### PR TITLE
【 エラー処理 】HTTP だったときの処理

### DIFF
--- a/js/pkg/certificate-Info.js
+++ b/js/pkg/certificate-Info.js
@@ -3,7 +3,7 @@ import * as urlMod from './url.js'
 export async function getCertInfo(url='', callback=async() => {}) {
     var [scheme, domain, _] = urlMod.breakUpUrl(url);
     if (scheme !== 'https') {
-        return;
+        throw new Error();
     }
 
     var api = 'https://jinkai-nitamago-cert.netlify.app/.netlify/functions/getcertinfo';

--- a/js/pkg/content.js
+++ b/js/pkg/content.js
@@ -17,31 +17,37 @@ export async function updateTab(tab) {
                 return [j.message.subject.CN, j.message.subject.O];
             } catch (err) {
                 if (err instanceof TypeError) {
-                    console.log("hi");
                     return [undefined, undefined];
                 } else {
                     console.log(err);
                 }
             }
         }
-    )
+    ).then((res) => {
+        return res.map((val) => {
+            return typeof val !== 'undefined' ? val : 'Unknown';
+        });
+    })
+    .catch ((err) => {
+        return ['disabled', 'disabled'];
+    });
 
     var [virusTotalUrlLink, virusTotalDomainLink, digicertLink] = await links.generateAllLinks(url.getCurrentTabUrl(tab));
 
-    // undefinedが保存できないから"unknown"で置き換えるロジックを追加
     await chrome.storage.session.set(
         {
             'tab': tab,
-            'commonName': typeof commonName !== 'undefined' ? commonName : 'Unknown',
-            'organization': typeof organization !== 'undefined' ? organization : 'Unknown',
+            'commonName': commonName,
+            'organization': organization,
             'virusTotalUrlLink': virusTotalUrlLink,
             'virusTotalDomainLink': virusTotalDomainLink,
             'digicertLink': digicertLink
         }
     );
 
-    console.log('commonName: ' + commonName);
-    console.log('Organization: ' + organization);
+    if (commonName === 'disabled' && organization === 'disabled') {
+        return;
+    }
 
     // 今回取得した証明書情報
     let sendCertInfo = {};

--- a/js/popup.js
+++ b/js/popup.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async(event) => {
 
     var theme = '';
     document.getElementById('ssl-organization').innerHTML = storageCache.organization;
-    if (typeof storageCache.organization === 'undefined') {
+    if (storageCache.organization === 'disabled') {
         theme = 'disabled';
         storageCache.virusTotalUrlLink = '#';
         storageCache.virusTotalDomainLink = '#';


### PR DESCRIPTION
- いままでは、`http` から始まるアドレスについて、正しいポップアップを表示できていなかった
- そこで、`http` については、`disabled` のポップアップを表示するようにした